### PR TITLE
change finally to else

### DIFF
--- a/paramiko_tutorial/client.py
+++ b/paramiko_tutorial/client.py
@@ -90,7 +90,7 @@ class RemoteClient:
         except SCPException as error:
             logger.error(error)
             raise error
-        finally:
+        else:
             logger.info(f'Uploaded {file} to {self.remote_path}')
             return upload
 


### PR DESCRIPTION
When returning a value in finally, the potentially raised error in the except is never handled: (https://stackoverflow.com/questions/53435114/python-exception-not-raised-if-finally-returns-value).

To achieve what apparently was aimed for, the else block should be used (which does makes sense when reading the `uploaded` log message "f'Uploaded {file} to {self.remote_path}").